### PR TITLE
gamescope-session.service cleanups

### DIFF
--- a/usr/bin/start-gamescope-session
+++ b/usr/bin/start-gamescope-session
@@ -30,6 +30,5 @@ logger Gamescope Session Ended - Performing Final Cleanup
 # We want to wait until *everything* has finished. We know systemd will have
 # queued a stop job on graphical-session-pre aleady
 # by also queuing up a job we can block until that completes
-systemctl --user unset-environment XDG_DESKTOP_PORTAL_DIR
 systemctl --user stop graphical-session-pre.target
 logger Gamescope Session Ended - Cleanup Complete

--- a/usr/bin/start-gamescope-session
+++ b/usr/bin/start-gamescope-session
@@ -18,9 +18,6 @@ dbus-update-activation-environment --systemd DESKTOP_SESSION `env | grep ^XDG_ |
 # Plasma resets this variable when it starts.
 systemctl --user set-environment XDG_DESKTOP_PORTAL_DIR=""
 
-# Remove these as they prevent gamescope-session from starting correctly
-systemctl --user unset-environment DISPLAY XAUTHORITY
-
 # If this shell script is killed then stop gamescope-session
 trap 'systemctl --user stop gamescope-session.target' HUP INT TERM
 

--- a/usr/bin/start-gamescope-session
+++ b/usr/bin/start-gamescope-session
@@ -33,8 +33,6 @@ logger Gamescope Session Ended - Performing Final Cleanup
 # We want to wait until *everything* has finished. We know systemd will have
 # queued a stop job on graphical-session-pre aleady
 # by also queuing up a job we can block until that completes
-rm -rf "$XDG_RUNTIME_DIR"/gamescope{.,-}*
-rm -f /tmp/gamescope-limiter*
 systemctl --user unset-environment XDG_DESKTOP_PORTAL_DIR
 systemctl --user stop graphical-session-pre.target
 logger Gamescope Session Ended - Cleanup Complete

--- a/usr/bin/start-gamescope-session
+++ b/usr/bin/start-gamescope-session
@@ -6,9 +6,6 @@ systemctl --user stop gamescope-session.target
 systemctl --user stop graphical-session-pre.target
 systemctl --user reset-failed
 
-# SDDM sets this to wayland but apps using Gamescope must use x11
-export XDG_SESSION_TYPE=x11
-
 # Update the enviroment with DESKTOP_SESSION and all XDG variables
 dbus-update-activation-environment --systemd DESKTOP_SESSION `env | grep ^XDG_ | cut -d = -f 1`
 

--- a/usr/lib/steamos/steam-set-session
+++ b/usr/lib/steamos/steam-set-session
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -e
 
-DISPLAY_MANAGER="$(readlink -f /etc/systemd/system/display-manager.service \
-                    | sed 's|.*/||')"
-
+DISPLAY_MANAGER="$(systemctl show -p Id --value display-manager)"
 case "${DISPLAY_MANAGER%.service}" in
     plasmalogin) CONF_FILE="/etc/plasmalogin.conf.d/zz-steamos-autologin.conf";;
     sddm) CONF_FILE="/etc/sddm.conf.d/zz-steamos-autologin.conf";;

--- a/usr/lib/systemd/user/cachyos-gamescope-autologin.service
+++ b/usr/lib/systemd/user/cachyos-gamescope-autologin.service
@@ -6,9 +6,7 @@ ConditionPathExists=!%t/gamescope-environment
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
-ExecStart=/usr/bin/true
-ExecStop=/usr/bin/pkexec /usr/lib/steamos/steam-set-session gamescope-session.desktop
+ExecStart=/usr/bin/pkexec /usr/lib/steamos/steam-set-session gamescope-session.desktop
 
 [Install]
 WantedBy=graphical-session.target

--- a/usr/lib/systemd/user/gamescope-session.service
+++ b/usr/lib/systemd/user/gamescope-session.service
@@ -19,4 +19,6 @@ Type=notify
 NotifyAccess=all
 # Make Steam's srt-logger write to the journal with it's own prefixes
 Environment=SRT_LOG_TO_JOURNAL=1
+# Remove these as they prevent gamescope-session from starting correctly
+UnsetEnvironment=DISPLAY XAUTHORITY
 Slice=session.slice

--- a/usr/lib/systemd/user/gamescope-session.service
+++ b/usr/lib/systemd/user/gamescope-session.service
@@ -14,6 +14,7 @@ Before=xdg-desktop-portal.service
 TimeoutStartSec=5
 TimeoutStopSec=10
 ExecStart=/usr/lib/steamos/gamescope-session
+ExecStopPost=/usr/bin/bash -c '/usr/bin/rm -rf "$XDG_RUNTIME_DIR"/gamescope{.,-}* /tmp/gamescope-limiter*'
 Type=notify
 NotifyAccess=all
 # Make Steam's srt-logger write to the journal with it's own prefixes

--- a/usr/lib/systemd/user/gamescope-session.service
+++ b/usr/lib/systemd/user/gamescope-session.service
@@ -18,7 +18,8 @@ ExecStopPost=/usr/bin/bash -c '/usr/bin/rm -rf "$XDG_RUNTIME_DIR"/gamescope{.,-}
 Type=notify
 NotifyAccess=all
 # Make Steam's srt-logger write to the journal with it's own prefixes
-Environment=SRT_LOG_TO_JOURNAL=1
+# SDDM sets XDG_SESSION_TYPE to wayland but apps using Gamescope must use x11
+Environment="SRT_LOG_TO_JOURNAL=1" "XDG_SESSION_TYPE=x11"
 # Remove these as they prevent gamescope-session from starting correctly
 UnsetEnvironment=DISPLAY XAUTHORITY
 Slice=session.slice


### PR DESCRIPTION
Addresses things pointed out by @ventureoo in https://github.com/CachyOS/CachyOS-Handheld/pull/98#issuecomment-3835950177.

Things to note:
- The keys `Environment` and `UnsetEnvironment` are only limited within the scope of the service. IOW, exporting global variables for the whole world isn't possible. The `export` and `set-environment` calls leftover in `start-gamescope-session` is unavoidable.
- When elevating permissions via pkexec, `$USER` resolves to `root`, so merging the two session select/set scripts isn't really possible. `loginctl terminate-session` doesn't work as it'll just crash the display manager. It might still be possible to just restart the display manager as the old script was doing, but all I got was system crashes. I'll need to look into this more.