### PR TITLE
Added OUTPUT_CONNECTOR env variable support to allow display selection

### DIFF
--- a/usr/lib/steamos/gamescope-session
+++ b/usr/lib/steamos/gamescope-session
@@ -242,8 +242,6 @@ read_gamescope_env() {
 # Spawned in parallel to read values from gamescope
 (read_gamescope_env &)
 
-output_connector="${OUTPUT_CONNECTOR:-*,eDP-1}"
-
 exec gamescope \
 	--generate-drm-mode fixed \
 	--xwayland-count 2 \

--- a/usr/lib/steamos/gamescope-session
+++ b/usr/lib/steamos/gamescope-session
@@ -242,6 +242,8 @@ read_gamescope_env() {
 # Spawned in parallel to read values from gamescope
 (read_gamescope_env &)
 
+output_connector="${OUTPUT_CONNECTOR:-*,eDP-1}"
+
 exec gamescope \
 	--generate-drm-mode fixed \
 	--xwayland-count 2 \
@@ -251,5 +253,5 @@ exec gamescope \
 	--fade-out-duration 200 \
 	--cursor-scale-height 720 \
 	-e -R "$socket" -T "$stats" \
-	-O '*',eDP-1 \
+	-O "$output_connector" \
 

--- a/usr/lib/steamos/gamescope-session
+++ b/usr/lib/steamos/gamescope-session
@@ -253,5 +253,5 @@ exec gamescope \
 	--fade-out-duration 200 \
 	--cursor-scale-height 720 \
 	-e -R "$socket" -T "$stats" \
-	-O "$output_connector" \
+	-O "${OUTPUT_CONNECTOR:-*,eDP-1}" \
 


### PR DESCRIPTION
I also faced the same issue with OUTPUT_CONNECTOR which was working before with ChimeraOS's gamescope-sesson-plus, so i have added it in minimalistic and safe way, if no env var set, it fallback to default value.
Should help with #2 , tested locally and working like a charm with my 2 displays, either DP-1 or HDMI-A-1
